### PR TITLE
fix: complete Notion MCP authentication with Bearer token headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
     ports:
       - "3005:3000"
     environment:
-      - NOTION_API_KEY=${NOTION_TOKEN}
+      - NOTION_TOKEN=${NOTION_TOKEN}
     restart: unless-stopped
 
   # Sequential Thinking MCP Server

--- a/mcp-servers/notion/notion.env
+++ b/mcp-servers/notion/notion.env
@@ -5,3 +5,4 @@
 
 PORT=7006
 SHELL_CMD="docker run -i --rm -e NOTION_TOKEN=${NOTION_INTEGRATION_TOKEN} mcp/notion"
+OPENAPI_MCP_HEADERS="{\"Authorization\": \"Bearer ${NOTION_INTEGRATION_TOKEN}\", \"Notion-Version\": \"2022-06-28\"}"


### PR DESCRIPTION
## Summary
Complete the Notion MCP authentication fixes on top of the merged infrastructure

## Changes Made
- **docker-compose.yml**: Fix `NOTION_API_KEY` → `NOTION_TOKEN` for consistency
- **notion.env**: Add `OPENAPI_MCP_HEADERS` for proper Bearer token authentication

## Technical Details
- Ensures consistent environment variable naming across all components
- Adds proper Bearer token headers for HTTP transport to Notion API
- Resolves 401 authentication errors that were blocking Notion MCP

## Verification
✅ Successfully tested on droplet - Notion MCP now authenticates properly
✅ Environment variable flow working: setup-env.sh → systemd → Docker → Notion API
✅ Bearer token format: `"Authorization": "Bearer ${NOTION_INTEGRATION_TOKEN}"`

This completes the Notion MCP authentication fixes that were started in the original PR but had merge conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)