### PR TITLE
feat(mcp): Issue #8 - Implement MCP Router using Pydantic AI client

### DIFF
--- a/agent-core/pyproject.toml
+++ b/agent-core/pyproject.toml
@@ -8,25 +8,19 @@ dependencies = [
     # FastAPI stack
     "fastapi[all]>=0.104.0",
     "uvicorn[standard]>=0.24.0",
-
     # Pydantic AI for agent orchestration
-    "pydantic-ai>=0.0.1b8",
-
+    "pydantic-ai[logfire,mcp]>=0.0.1b8",
     # Database
     "sqlalchemy[asyncio]>=2.0.0",
     "psycopg[binary]>=3.1.0",
     "alembic>=1.12.0",
-
     # Crypto for token encryption
     "cryptography>=41.0.0",
-
     # HTTP clients for MCP
     "httpx>=0.25.0",
     "websockets>=12.0",
-
     # Anthropic client
     "anthropic>=0.7.0",
-
     # Utilities
     "python-dotenv>=1.0.0",
     "structlog>=23.1.0",

--- a/agent-core/src/routers/health.py
+++ b/agent-core/src/routers/health.py
@@ -5,7 +5,7 @@ Provides /healthz endpoint for load balancers and monitoring systems
 to verify the service is running and healthy.
 """
 
-from typing import Dict
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, status
 
@@ -87,3 +87,158 @@ async def readiness_probe() -> Dict[str, bool]:
     # - Cache service available
 
     return {"ready": True}
+
+
+@router.get(
+    "/healthz/mcp",
+    response_model=Dict[str, Any],
+    status_code=status.HTTP_200_OK,
+    summary="MCP servers health",
+    description="Returns health status of all connected MCP servers",
+    response_description="MCP servers health summary",
+)
+async def mcp_health() -> Dict[str, Any]:
+    """
+    MCP servers health check endpoint.
+
+    Shows the health status of all configured MCP servers including:
+    - Connection status (healthy/unhealthy/degraded)
+    - Server-specific health metrics
+    - Average latency across healthy servers
+    - Cache statistics
+
+    Returns:
+        Dict containing MCP health summary and per-server status
+
+    Example response:
+        {
+            "status": "healthy",
+            "healthy_servers": 3,
+            "total_servers": 3,
+            "average_latency_ms": 45.2,
+            "servers": {
+                "time": {
+                    "status": "healthy",
+                    "last_success": "2024-01-20T10:30:00",
+                    "latency_ms": 42.1,
+                    "error": null
+                },
+                ...
+            },
+            "cache": {
+                "total_entries": 3,
+                "total_hits": 125,
+                "ttl_seconds": 600
+            }
+        }
+    """
+    # Import here to avoid circular dependency
+    from src.services.mcp_router import get_mcp_router
+
+    try:
+        # Get the MCP router instance
+        router_instance = await get_mcp_router()
+
+        # Get health summary
+        health_summary = await router_instance.get_health_summary()
+
+        # Get cache statistics
+        cache_stats = router_instance.get_cache_stats()
+
+        # Combine health and cache info
+        return {
+            **health_summary,
+            "cache": cache_stats,
+        }
+
+    except Exception as e:
+        logger.error("Failed to get MCP health", error=str(e))
+        return {
+            "status": "error",
+            "error": str(e),
+            "healthy_servers": 0,
+            "total_servers": 0,
+        }
+
+
+@router.get(
+    "/mcp/tools",
+    response_model=Dict[str, Any],
+    status_code=status.HTTP_200_OK,
+    summary="List MCP tools",
+    description="Returns all available tools from connected MCP servers",
+    response_description="Unified tool registry",
+)
+async def list_mcp_tools(
+    force_refresh: bool = False,
+) -> Dict[str, Any]:
+    """
+    List all available MCP tools.
+
+    Returns a unified registry of all tools discovered from connected
+    MCP servers. Tools are cached for performance with configurable TTL.
+
+    Args:
+        force_refresh: Bypass cache and force fresh discovery
+
+    Returns:
+        Dict containing tools organized by server
+
+    Example response:
+        {
+            "total_tools": 15,
+            "servers": {
+                "time": [
+                    {
+                        "name": "time_get_current_time",
+                        "original_name": "get_current_time",
+                        "description": "Get the current time",
+                        "input_schema": {...}
+                    }
+                ],
+                ...
+            }
+        }
+    """
+    # Import here to avoid circular dependency
+    from src.services.mcp_router import get_mcp_router
+
+    try:
+        # Get the MCP router instance
+        router_instance = await get_mcp_router()
+
+        # Discover all tools
+        tools_by_server = await router_instance.discover_all_tools(
+            force_refresh=force_refresh
+        )
+
+        # Count total tools
+        total_tools = sum(len(tools) for tools in tools_by_server.values())
+
+        # Convert ToolDef objects to dicts for JSON response
+        tools_dict = {}
+        for server, tools in tools_by_server.items():
+            tools_dict[server] = [
+                {
+                    "name": tool.name,
+                    "original_name": tool.original_name,
+                    "description": tool.description,
+                    "input_schema": tool.input_schema,
+                    "output_schema": tool.output_schema,
+                }
+                for tool in tools
+            ]
+
+        return {
+            "total_tools": total_tools,
+            "servers": tools_dict,
+            "cache_stats": router_instance.get_cache_stats(),
+        }
+
+    except Exception as e:
+        logger.error("Failed to list MCP tools", error=str(e))
+        return {
+            "error": str(e),
+            "total_tools": 0,
+            "servers": {},
+        }

--- a/agent-core/src/services/mcp_router.py
+++ b/agent-core/src/services/mcp_router.py
@@ -1,2 +1,704 @@
-# MCP Router service
-# TODO: Implement MCP router with tool discovery and health checks
+"""
+MCP Router for tool discovery and connection management.
+
+This module connects to remote MCP servers using Pydantic AI's MCP client,
+discovers their tools, caches results, and provides health monitoring.
+"""
+
+import asyncio
+import time
+from contextlib import AsyncExitStack
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import httpx
+import logfire
+from pydantic_ai.mcp import MCPServerSSE, MCPServerStreamableHTTP
+
+from src.config import Settings, get_settings
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Configure logfire for observability (optional)
+# This gives us automatic tracing of MCP operations
+try:
+    logfire.configure(service_name="alfred-agent-core")
+except Exception:
+    # Logfire is optional, continue without it
+    pass
+
+
+@dataclass
+class MCPServerConfig:
+    """Configuration for a single MCP server."""
+
+    name: str
+    url: str
+    transport: str = "streamable_http"  # or "sse"
+    tool_prefix: Optional[str] = None  # Prefix to avoid tool name collisions
+    health_check_interval: int = 30  # seconds
+    enabled: bool = True
+
+
+@dataclass
+class MCPServerStatus:
+    """Health status for an MCP server."""
+
+    server_name: str
+    status: str  # "healthy", "unhealthy", "connecting"
+    last_ping_time: Optional[datetime] = None
+    last_success_time: Optional[datetime] = None
+    ping_latency_ms: Optional[float] = None
+    error_message: Optional[str] = None
+    consecutive_failures: int = 0
+
+
+@dataclass
+class ToolCacheEntry:
+    """Cached tool discovery result."""
+
+    tools: List[Any]  # List of tool definitions
+    cached_at: datetime
+    cache_hit_count: int = 0
+
+
+@dataclass
+class ToolDef:
+    """Normalized tool definition across all servers."""
+
+    server: str  # Which server this tool belongs to
+    name: str  # Tool name (possibly prefixed)
+    original_name: str  # Original unprefixed name
+    description: Optional[str]
+    input_schema: Optional[Dict[str, Any]]
+    output_schema: Optional[Dict[str, Any]]
+
+
+class MCPRouter:
+    """
+    Router for managing connections to multiple MCP servers.
+
+    This class:
+    - Maintains connections to configured MCP servers using Pydantic AI
+    - Caches tool discovery for performance (5-15 min TTL)
+    - Provides health monitoring via MCP ping
+    - Returns unified toolsets for Pydantic AI agents
+    """
+
+    def __init__(
+        self,
+        settings: Optional[Settings] = None,
+        cache_ttl_minutes: int = 10,
+        http_timeout_seconds: float = 30.0,
+    ):
+        """
+        Initialize the MCP Router.
+
+        Args:
+            settings: Application settings with MCP server URLs
+            cache_ttl_minutes: Tool cache TTL in minutes (default 10)
+            http_timeout_seconds: HTTP timeout for MCP requests
+        """
+        self.settings = settings or get_settings()
+        self.cache_ttl = timedelta(minutes=cache_ttl_minutes)
+        self.http_timeout = http_timeout_seconds
+
+        # Server instances: server_name -> MCPServer instance
+        self.servers: Dict[str, Any] = {}
+
+        # Tool cache: server_name -> ToolCacheEntry
+        self.tool_cache: Dict[str, ToolCacheEntry] = {}
+
+        # Health status: server_name -> MCPServerStatus
+        self.health_status: Dict[str, MCPServerStatus] = {}
+
+        # Background tasks for health monitoring
+        self.health_check_tasks: Dict[str, asyncio.Task] = {}
+
+        # Context manager for server lifecycles
+        self.exit_stack: Optional[AsyncExitStack] = None
+
+        # Shared HTTP client with custom timeouts and settings
+        self.http_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(self.http_timeout),
+            follow_redirects=True,
+            # Add any custom headers, proxies, or TLS config here
+        )
+
+        # Initialize server configurations from environment
+        self.server_configs = self._load_server_configs()
+
+    def _load_server_configs(self) -> List[MCPServerConfig]:
+        """
+        Load MCP server configurations from settings.
+
+        Returns:
+            List of MCPServerConfig objects
+        """
+        configs = []
+
+        # Map of server names to their production URLs
+        # Based on MCP_PROXY_IMPLEMENTATION.md
+        server_mapping = {
+            "time": "https://mcp-time.artemsys.ai",
+            "github-personal": "https://mcp-github-personal.artemsys.ai",
+            "github-work": "https://mcp-github-work.artemsys.ai",
+            "notion": "https://mcp-notion.artemsys.ai",
+            "fetch": "https://mcp-fetch.artemsys.ai",
+            "sequential-thinking": "https://mcp-sequential.artemsys.ai",
+            "filesystem": "https://mcp-filesystem.artemsys.ai",
+            "playwright": "https://mcp-playwright.artemsys.ai",
+            "memory": "https://mcp-memory.artemsys.ai",
+            "atlassian": "https://mcp-atlassian.artemsys.ai",
+        }
+
+        # For MVP Week 1, start with a subset
+        enabled_servers = ["time", "github-personal", "notion"]
+
+        for server_name in enabled_servers:
+            if server_name in server_mapping:
+                configs.append(
+                    MCPServerConfig(
+                        name=server_name,
+                        url=server_mapping[server_name],
+                        transport="streamable_http",  # All use Streamable HTTP via mcp-proxy
+                        tool_prefix=f"{server_name}_",  # Prefix tools to avoid collisions
+                        health_check_interval=30,
+                        enabled=True,
+                    )
+                )
+
+        logger.info(
+            "Loaded MCP server configurations",
+            server_count=len(configs),
+            servers=[c.name for c in configs],
+        )
+
+        return configs
+
+    async def initialize(self) -> None:
+        """
+        Initialize connections to all configured MCP servers.
+
+        This method:
+        1. Creates MCPServer instances for each server
+        2. Opens connections using async context managers
+        3. Starts health monitoring tasks
+        """
+        logger.info("Initializing MCP Router", server_count=len(self.server_configs))
+
+        # Create async exit stack for managing server lifecycles
+        self.exit_stack = AsyncExitStack()
+
+        # Create server instances
+        for config in self.server_configs:
+            if not config.enabled:
+                continue
+
+            try:
+                # Create appropriate server instance based on transport
+                if config.transport == "streamable_http":
+                    # Streamable HTTP endpoint is at /mcp
+                    server = MCPServerStreamableHTTP(
+                        url=f"{config.url}/mcp",
+                        tool_prefix=config.tool_prefix,
+                        http_client=self.http_client,  # Use shared HTTP client
+                    )
+                else:
+                    # SSE endpoint is at /sse
+                    server = MCPServerSSE(
+                        url=f"{config.url}/sse",
+                        tool_prefix=config.tool_prefix,
+                        http_client=self.http_client,
+                    )
+
+                # Store server instance
+                self.servers[config.name] = server
+
+                # Enter context manager to initialize connection
+                # Pydantic MCP handles protocol initialization internally
+                await self.exit_stack.enter_async_context(server)
+
+                # Initialize health status
+                self.health_status[config.name] = MCPServerStatus(
+                    server_name=config.name,
+                    status="healthy",
+                    last_success_time=datetime.now(),
+                )
+
+                logger.info(
+                    "Successfully connected to MCP server",
+                    server=config.name,
+                    transport=config.transport,
+                )
+
+            except Exception as e:
+                logger.error(
+                    "Failed to connect to MCP server",
+                    server=config.name,
+                    error=str(e),
+                )
+                self.health_status[config.name] = MCPServerStatus(
+                    server_name=config.name,
+                    status="unhealthy",
+                    error_message=str(e),
+                )
+
+        # Perform initial tool discovery
+        await self.discover_all_tools(force_refresh=True)
+
+        # Start health monitoring for connected servers
+        for server_name in self.servers:
+            self._start_health_monitoring(server_name)
+
+    async def _discover_server_tools(
+        self, server_name: str, force_refresh: bool = False
+    ) -> List[ToolDef]:
+        """
+        Discover tools from a specific MCP server with caching.
+
+        Args:
+            server_name: Name of the server
+            force_refresh: Bypass cache if True
+
+        Returns:
+            List of normalized ToolDef objects
+        """
+        # Check cache first
+        if not force_refresh and server_name in self.tool_cache:
+            cache_entry = self.tool_cache[server_name]
+            cache_age = datetime.now() - cache_entry.cached_at
+
+            if cache_age < self.cache_ttl:
+                # Cache hit
+                cache_entry.cache_hit_count += 1
+                logger.debug(
+                    "Tool cache hit",
+                    server=server_name,
+                    cache_age_seconds=cache_age.total_seconds(),
+                    hit_count=cache_entry.cache_hit_count,
+                )
+                return cache_entry.tools
+
+        # Cache miss or forced refresh - discover tools
+        logger.info(
+            "Discovering tools from MCP server",
+            server=server_name,
+            force_refresh=force_refresh,
+        )
+
+        server = self.servers.get(server_name)
+        if not server:
+            logger.warning("No connection for server", server=server_name)
+            return []
+
+        try:
+            # Use Pydantic MCP's list_tools method
+            # This handles the protocol details and returns typed tools
+            tools = await server.list_tools()
+
+            # Normalize tools to our ToolDef format
+            tool_defs = []
+            for tool in tools:
+                # Tools from Pydantic MCP have these attributes
+                tool_def = ToolDef(
+                    server=server_name,
+                    name=tool.name,  # Already prefixed by Pydantic MCP if configured
+                    original_name=tool.name.removeprefix(f"{server_name}_")
+                    if tool.name.startswith(f"{server_name}_")
+                    else tool.name,
+                    description=getattr(tool, "description", None),
+                    input_schema=getattr(tool, "parameters_json_schema", None),
+                    output_schema=None,  # MCP tools don't typically have output schemas
+                )
+                tool_defs.append(tool_def)
+
+            # Cache the result
+            self.tool_cache[server_name] = ToolCacheEntry(
+                tools=tool_defs,
+                cached_at=datetime.now(),
+            )
+
+            logger.info(
+                "Discovered tools",
+                server=server_name,
+                tool_count=len(tool_defs),
+                tool_names=[t.name for t in tool_defs] if tool_defs else [],
+            )
+
+            return tool_defs
+
+        except Exception as e:
+            logger.error(
+                "Failed to discover tools",
+                server=server_name,
+                error=str(e),
+            )
+            return []
+
+    async def discover_all_tools(
+        self, force_refresh: bool = False
+    ) -> Dict[str, List[ToolDef]]:
+        """
+        Discover tools from all connected MCP servers.
+
+        Args:
+            force_refresh: Bypass cache if True
+
+        Returns:
+            Dictionary mapping server names to tool lists
+        """
+        logger.info(
+            "Discovering tools from all servers",
+            server_count=len(self.servers),
+            force_refresh=force_refresh,
+        )
+
+        # Discover tools from each server concurrently
+        tasks = {
+            server_name: self._discover_server_tools(server_name, force_refresh)
+            for server_name in self.servers
+        }
+
+        results = {}
+        for server_name, task_coro in tasks.items():
+            try:
+                results[server_name] = await task_coro
+            except Exception as e:
+                logger.error(
+                    "Failed to discover tools from server",
+                    server=server_name,
+                    error=str(e),
+                )
+                results[server_name] = []
+
+        return results
+
+    def get_unified_toolsets(self) -> List[Any]:
+        """
+        Get all MCP server instances as toolsets for Pydantic AI agents.
+
+        Returns:
+            List of MCP server instances (each is a toolset)
+        """
+        toolsets = []
+
+        for server_name, server in self.servers.items():
+            status = self.health_status.get(server_name)
+            if status and status.status == "healthy":
+                toolsets.append(server)
+            else:
+                logger.debug(
+                    "Skipping unhealthy server",
+                    server=server_name,
+                )
+
+        logger.info(
+            "Providing unified toolsets",
+            toolset_count=len(toolsets),
+            servers=[name for name, s in self.servers.items() if s in toolsets],
+        )
+
+        return toolsets
+
+    async def call_tool(
+        self,
+        server_name: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """
+        Call a tool on a specific MCP server.
+
+        Args:
+            server_name: Name of the server
+            tool_name: Name of the tool (without prefix)
+            arguments: Tool arguments
+            metadata: Optional metadata for the call
+
+        Returns:
+            Tool execution result
+        """
+        server = self.servers.get(server_name)
+        if not server:
+            raise ValueError(f"No server found: {server_name}")
+
+        # Add server prefix to tool name if configured
+        config = next((c for c in self.server_configs if c.name == server_name), None)
+        if config and config.tool_prefix:
+            prefixed_name = f"{config.tool_prefix}{tool_name}"
+        else:
+            prefixed_name = tool_name
+
+        logger.info(
+            "Calling tool",
+            server=server_name,
+            tool=prefixed_name,
+            args_keys=list(arguments.keys()),
+        )
+
+        try:
+            # Use Pydantic MCP's direct_call_tool method
+            # This handles the protocol and returns the result
+            result = await server.direct_call_tool(
+                prefixed_name,
+                arguments,
+                metadata=metadata,
+            )
+
+            logger.info(
+                "Tool call successful",
+                server=server_name,
+                tool=prefixed_name,
+            )
+
+            return result
+
+        except Exception as e:
+            logger.error(
+                "Tool call failed",
+                server=server_name,
+                tool=prefixed_name,
+                error=str(e),
+            )
+            raise
+
+    def _start_health_monitoring(self, server_name: str) -> None:
+        """
+        Start background health monitoring for a server.
+
+        Args:
+            server_name: Name of the server to monitor
+        """
+        # Cancel existing task if any
+        if server_name in self.health_check_tasks:
+            self.health_check_tasks[server_name].cancel()
+
+        # Start new monitoring task
+        task = asyncio.create_task(self._health_check_loop(server_name))
+        self.health_check_tasks[server_name] = task
+
+        logger.debug(
+            "Started health monitoring",
+            server=server_name,
+        )
+
+    async def _health_check_loop(self, server_name: str) -> None:
+        """
+        Background task for periodic health checks.
+
+        Args:
+            server_name: Name of the server to monitor
+        """
+        config = next((c for c in self.server_configs if c.name == server_name), None)
+
+        if not config:
+            logger.error("No config for health check", server=server_name)
+            return
+
+        while True:
+            try:
+                # Wait for next check interval with some jitter
+                jitter = (
+                    asyncio.current_task().get_name().encode()[0] % 5
+                )  # 0-4 seconds
+                await asyncio.sleep(config.health_check_interval + jitter)
+
+                # Perform health check
+                await self._check_server_health(server_name)
+
+            except asyncio.CancelledError:
+                logger.debug("Health check cancelled", server=server_name)
+                break
+            except Exception as e:
+                logger.error(
+                    "Health check error",
+                    server=server_name,
+                    error=str(e),
+                )
+
+    async def _check_server_health(self, server_name: str) -> None:
+        """
+        Check health of a single MCP server using ping.
+
+        Args:
+            server_name: Name of the server to check
+        """
+        status = self.health_status.get(server_name)
+        if not status:
+            return
+
+        server = self.servers.get(server_name)
+        if not server:
+            status.status = "unhealthy"
+            status.error_message = "No connection"
+            return
+
+        try:
+            # Measure ping latency
+            start_time = time.perf_counter()
+
+            # Pydantic MCP doesn't expose ping directly, but we can use list_tools
+            # as a lightweight health check (it's cached anyway)
+            # Alternatively, we could make a direct ping request through the client
+            await server.list_tools()
+
+            # Calculate latency
+            latency_ms = (time.perf_counter() - start_time) * 1000
+
+            # Update status
+            status.status = "healthy"
+            status.last_ping_time = datetime.now()
+            status.last_success_time = datetime.now()
+            status.ping_latency_ms = latency_ms
+            status.consecutive_failures = 0
+            status.error_message = None
+
+            logger.debug(
+                "Health check successful",
+                server=server_name,
+                latency_ms=round(latency_ms, 2),
+            )
+
+        except Exception as e:
+            # Update failure status
+            status.status = "unhealthy"
+            status.last_ping_time = datetime.now()
+            status.consecutive_failures += 1
+            status.error_message = str(e)
+
+            logger.warning(
+                "Health check failed",
+                server=server_name,
+                consecutive_failures=status.consecutive_failures,
+                error=str(e),
+            )
+
+    async def get_health_summary(self) -> Dict[str, Any]:
+        """
+        Get aggregated health status for all MCP servers.
+
+        Returns:
+            Dictionary with overall status and per-server details
+        """
+        healthy_count = sum(
+            1 for s in self.health_status.values() if s.status == "healthy"
+        )
+        total_count = len(self.health_status)
+
+        # Calculate average latency for healthy servers
+        latencies = [
+            s.ping_latency_ms
+            for s in self.health_status.values()
+            if s.status == "healthy" and s.ping_latency_ms is not None
+        ]
+        avg_latency = sum(latencies) / len(latencies) if latencies else None
+
+        # Overall status
+        if healthy_count == total_count:
+            overall_status = "healthy"
+        elif healthy_count > 0:
+            overall_status = "degraded"
+        else:
+            overall_status = "unhealthy"
+
+        return {
+            "status": overall_status,
+            "healthy_servers": healthy_count,
+            "total_servers": total_count,
+            "average_latency_ms": round(avg_latency, 2) if avg_latency else None,
+            "servers": {
+                name: {
+                    "status": status.status,
+                    "last_success": status.last_success_time.isoformat()
+                    if status.last_success_time
+                    else None,
+                    "latency_ms": status.ping_latency_ms,
+                    "error": status.error_message,
+                }
+                for name, status in self.health_status.items()
+            },
+        }
+
+    def get_cache_stats(self) -> Dict[str, Any]:
+        """
+        Get cache statistics for monitoring.
+
+        Returns:
+            Dictionary with cache metrics
+        """
+        total_entries = len(self.tool_cache)
+        total_hits = sum(entry.cache_hit_count for entry in self.tool_cache.values())
+
+        # Calculate cache ages
+        now = datetime.now()
+        cache_ages = {
+            server: (now - entry.cached_at).total_seconds()
+            for server, entry in self.tool_cache.items()
+        }
+
+        return {
+            "total_entries": total_entries,
+            "total_hits": total_hits,
+            "ttl_seconds": self.cache_ttl.total_seconds(),
+            "entries": {
+                server: {
+                    "age_seconds": age,
+                    "hit_count": self.tool_cache[server].cache_hit_count,
+                    "expired": age > self.cache_ttl.total_seconds(),
+                }
+                for server, age in cache_ages.items()
+            },
+        }
+
+    async def shutdown(self) -> None:
+        """
+        Clean shutdown of all connections and background tasks.
+        """
+        logger.info("Shutting down MCP Router")
+
+        # Cancel all health check tasks
+        for task in self.health_check_tasks.values():
+            task.cancel()
+
+        # Wait for tasks to complete
+        await asyncio.gather(*self.health_check_tasks.values(), return_exceptions=True)
+
+        # Close all server connections via exit stack
+        if self.exit_stack:
+            await self.exit_stack.aclose()
+
+        # Close HTTP client
+        await self.http_client.aclose()
+
+        # Clear registries
+        self.servers.clear()
+        self.tool_cache.clear()
+        self.health_status.clear()
+        self.health_check_tasks.clear()
+
+        logger.info("MCP Router shutdown complete")
+
+
+# Module-level router instance (singleton pattern)
+_router_instance: Optional[MCPRouter] = None
+
+
+async def get_mcp_router() -> MCPRouter:
+    """
+    Get the singleton MCP Router instance.
+
+    Returns:
+        The initialized MCPRouter instance
+    """
+    global _router_instance
+
+    if _router_instance is None:
+        _router_instance = MCPRouter()
+        await _router_instance.initialize()
+
+    return _router_instance

--- a/agent-core/uv.lock
+++ b/agent-core/uv.lock
@@ -25,7 +25,7 @@ dependencies = [
     { name = "fastapi", extra = ["all"] },
     { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
-    { name = "pydantic-ai" },
+    { name = "pydantic-ai", extra = ["logfire"] },
     { name = "python-dotenv" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
@@ -66,7 +66,7 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.4.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1.0" },
-    { name = "pydantic-ai", specifier = ">=0.0.1b8" },
+    { name = "pydantic-ai", extras = ["logfire", "mcp"], specifier = ">=0.0.1b8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -564,6 +564,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693, upload-time = "2025-01-22T15:41:29.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702, upload-time = "2025-01-22T15:41:25.929Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -801,6 +810,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1b/da30fa6e2966942d7028a58eb7aa7d04544dcc3aa66194365b2e0adac570/google_genai-1.31.0.tar.gz", hash = "sha256:8572b47aa684357c3e5e10d290ec772c65414114939e3ad2955203e27cd2fcbc", size = 233482, upload-time = "2025-08-18T23:40:21.733Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/27/1525bc9cbec58660f0842ebcbfe910a1dde908c2672373804879666e0bb8/google_genai-1.31.0-py3-none-any.whl", hash = "sha256:5c6959bcf862714e8ed0922db3aaf41885bacf6318751b3421bf1e459f78892f", size = 231876, upload-time = "2025-08-18T23:40:20.385Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903, upload-time = "2025-04-14T10:17:02.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530, upload-time = "2025-04-14T10:17:01.271Z" },
 ]
 
 [[package]]
@@ -1163,6 +1184,24 @@ wheels = [
 ]
 
 [[package]]
+name = "logfire"
+version = "4.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "executing" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/66/fa75d419bcbc9e4575fe3b906e578aaf167d7ee4e678a30634beaa70ca4a/logfire-4.3.6.tar.gz", hash = "sha256:419b6d14f797fedc31c8b516a44c377e4e7d344f79e19addcee40d57c3bf8a61", size = 519708, upload-time = "2025-08-26T07:59:26.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/3b/168cf54ecb4e13e3f8c55f6c38c48e503d8ed4c856ce18ada8b160533ee5/logfire-4.3.6-py3-none-any.whl", hash = "sha256:86002ea7193ee710fddf7481fc497ab2896d13d8266f38a6cf921de4b00219c7", size = 214660, upload-time = "2025-08-26T07:59:23.08Z" },
+]
+
+[[package]]
 name = "logfire-api"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1433,6 +1472,90 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/d2/c782c88b8afbf961d6972428821c302bd1e9e7bc361352172f0ca31296e2/opentelemetry_api-1.36.0.tar.gz", hash = "sha256:9a72572b9c416d004d492cbc6e61962c0501eaf945ece9b5a0f56597d8348aa0", size = 64780, upload-time = "2025-07-29T15:12:06.02Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/ee/6b08dde0a022c463b88f55ae81149584b125a42183407dc1045c486cc870/opentelemetry_api-1.36.0-py3-none-any.whl", hash = "sha256:02f20bcacf666e1333b6b1f04e647dc1d5111f86b8e510238fcc56d7762cda8c", size = 65564, upload-time = "2025-07-29T15:11:47.998Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/da/7747e57eb341c59886052d733072bc878424bf20f1d8cf203d508bbece5b/opentelemetry_exporter_otlp_proto_common-1.36.0.tar.gz", hash = "sha256:6c496ccbcbe26b04653cecadd92f73659b814c6e3579af157d8716e5f9f25cbf", size = 20302, upload-time = "2025-07-29T15:12:07.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/ed/22290dca7db78eb32e0101738366b5bbda00d0407f00feffb9bf8c3fdf87/opentelemetry_exporter_otlp_proto_common-1.36.0-py3-none-any.whl", hash = "sha256:0fc002a6ed63eac235ada9aa7056e5492e9a71728214a61745f6ad04b923f840", size = 18349, upload-time = "2025-07-29T15:11:51.327Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/85/6632e7e5700ba1ce5b8a065315f92c1e6d787ccc4fb2bdab15139eaefc82/opentelemetry_exporter_otlp_proto_http-1.36.0.tar.gz", hash = "sha256:dd3637f72f774b9fc9608ab1ac479f8b44d09b6fb5b2f3df68a24ad1da7d356e", size = 16213, upload-time = "2025-07-29T15:12:08.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/41/a680d38b34f8f5ddbd78ed9f0042e1cc712d58ec7531924d71cb1e6c629d/opentelemetry_exporter_otlp_proto_http-1.36.0-py3-none-any.whl", hash = "sha256:3d769f68e2267e7abe4527f70deb6f598f40be3ea34c6adc35789bea94a32902", size = 18752, upload-time = "2025-07-29T15:11:53.164Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/37/cf17cf28f945a3aca5a038cfbb45ee01317d4f7f3a0e5209920883fe9b08/opentelemetry_instrumentation-0.57b0.tar.gz", hash = "sha256:f2a30135ba77cdea2b0e1df272f4163c154e978f57214795d72f40befd4fcf05", size = 30807, upload-time = "2025-07-29T15:42:44.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/6f/f20cd1542959f43fb26a5bf9bb18cd81a1ea0700e8870c8f369bd07f5c65/opentelemetry_instrumentation-0.57b0-py3-none-any.whl", hash = "sha256:9109280f44882e07cec2850db28210b90600ae9110b42824d196de357cbddf7e", size = 32460, upload-time = "2025-07-29T15:41:40.883Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/02/f6556142301d136e3b7e95ab8ea6a5d9dc28d879a99f3dd673b5f97dca06/opentelemetry_proto-1.36.0.tar.gz", hash = "sha256:0f10b3c72f74c91e0764a5ec88fd8f1c368ea5d9c64639fb455e2854ef87dd2f", size = 46152, upload-time = "2025-07-29T15:12:15.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/57/3361e06136225be8180e879199caea520f38026f8071366241ac458beb8d/opentelemetry_proto-1.36.0-py3-none-any.whl", hash = "sha256:151b3bf73a09f94afc658497cf77d45a565606f62ce0c17acb08cd9937ca206e", size = 72537, upload-time = "2025-07-29T15:12:02.243Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/85/8567a966b85a2d3f971c4d42f781c305b2b91c043724fa08fd37d158e9dc/opentelemetry_sdk-1.36.0.tar.gz", hash = "sha256:19c8c81599f51b71670661ff7495c905d8fdf6976e41622d5245b791b06fa581", size = 162557, upload-time = "2025-07-29T15:12:16.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/59/7bed362ad1137ba5886dac8439e84cd2df6d087be7c09574ece47ae9b22c/opentelemetry_sdk-1.36.0-py3-none-any.whl", hash = "sha256:19fe048b42e98c5c1ffe85b569b7073576ad4ce0bcb6e9b4c6a39e890a6c45fb", size = 119995, upload-time = "2025-07-29T15:12:03.181Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.57b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/31/67dfa252ee88476a29200b0255bda8dfc2cf07b56ad66dc9a6221f7dc787/opentelemetry_semantic_conventions-0.57b0.tar.gz", hash = "sha256:609a4a79c7891b4620d64c7aac6898f872d790d75f22019913a660756f27ff32", size = 124225, upload-time = "2025-07-29T15:12:17.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/75/7d591371c6c39c73de5ce5da5a2cc7b72d1d1cd3f8f4638f553c01c37b11/opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl", hash = "sha256:757f7e76293294f124c827e514c2a3144f191ef175b069ce8d1211e1e38e9e78", size = 201627, upload-time = "2025-07-29T15:12:04.174Z" },
 ]
 
 [[package]]
@@ -1768,6 +1891,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/fa/23d79dafab91b5d2b354bf4467835553dcd386db7cc7e4de406824ebaf37/pydantic_ai-0.7.6.tar.gz", hash = "sha256:e49df21ae1f12b44771c0fe706cca90127ef31390fccc35ff9c3fd25036c7b2e", size = 43770934, upload-time = "2025-08-26T13:02:12.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/e6/0a6999bd1de76e2351a533cbf08f0a80dbcbadac5f23e5b2aeab37f533f3/pydantic_ai-0.7.6-py3-none-any.whl", hash = "sha256:5590424354564f18dabc8aa5438101ef255725c71761c6bd0f66e21e5e096444", size = 10189, upload-time = "2025-08-26T13:02:01.316Z" },
+]
+
+[package.optional-dependencies]
+logfire = [
+    { name = "logfire" },
 ]
 
 [[package]]
@@ -2898,6 +3026,65 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Implements MCPRouter class using Pydantic AI's built-in MCP client
- Provides infrastructure layer for managing MCP server connections
- Caches tool discovery with 10-minute TTL for performance

## Implementation Details
- Uses `MCPServerStreamableHTTP` from `pydantic_ai.mcp` module
- Manages connections to MCP servers at `https://mcp-*.artemsys.ai`
- Implements health monitoring with 30-second interval checks
- Provides unified toolsets for agent orchestrator integration
- Uses AsyncExitStack for proper lifecycle management

## Endpoints Added
- `GET /healthz/mcp` - Returns aggregated health status of all MCP servers
- `GET /mcp/tools` - Returns unified tool registry with caching

## Key Features
- Tool discovery caching (10-minute TTL)
- Health status tracking per server
- Direct tool invocation support via `call_tool` method
- Cache statistics tracking
- Logfire support for observability (optional)

## Testing Notes
- Health checks use `list_tools` as proxy for server availability
- Tool names are prefixed with server name to avoid collisions
- Cache can be forced to refresh with `force_refresh` parameter

Closes #8