### PR TITLE
feat(metering): Token usage tracking with budget warnings (#26)

### DIFF
--- a/agent-core/src/db/migrations/versions/31532600a9f6_add_token_usage_tracking_tables.py
+++ b/agent-core/src/db/migrations/versions/31532600a9f6_add_token_usage_tracking_tables.py
@@ -31,7 +31,7 @@ def upgrade() -> None:
     # Create token_usage table (append-only log)
     op.create_table(
         "token_usage",
-        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
         sa.Column("request_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("workspace_id", sa.String(255), nullable=True),
@@ -42,7 +42,9 @@ def upgrade() -> None:
         sa.Column("model_name", sa.String(100), nullable=True),
         sa.Column("provider", sa.String(50), nullable=True),
         sa.Column("tool_calls_count", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("cache_hit", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "cache_hit", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
         sa.Column("status", sa.String(10), nullable=False, server_default="ok"),
         sa.Column(
             "created_at",
@@ -50,7 +52,6 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.func.now(),
         ),
-        sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint(
             "request_id", name="uq_token_usage_request_id"
         ),  # Idempotency
@@ -79,7 +80,7 @@ def upgrade() -> None:
     op.create_table(
         "token_usage_rollup_daily",
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
-        sa.Column("workspace_id", sa.String(255), nullable=True),
+        sa.Column("workspace_id", sa.String(255), nullable=False, server_default=""),
         sa.Column("day", sa.Date(), nullable=False),
         sa.Column("input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
         sa.Column("output_tokens", sa.BigInteger(), nullable=False, server_default="0"),
@@ -126,7 +127,9 @@ def upgrade() -> None:
             nullable=False,
             server_default="80",
         ),
-        sa.Column("soft_block", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "soft_block", sa.Boolean(), nullable=False, server_default=sa.text("true")
+        ),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),

--- a/agent-core/src/db/migrations/versions/31532600a9f6_add_token_usage_tracking_tables.py
+++ b/agent-core/src/db/migrations/versions/31532600a9f6_add_token_usage_tracking_tables.py
@@ -1,0 +1,200 @@
+"""add token usage tracking tables
+
+Revision ID: 31532600a9f6
+Revises: 22f5e329390a
+Create Date: 2025-09-09 18:31:25.620621
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "31532600a9f6"
+down_revision: Union[str, None] = "22f5e329390a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Create token usage tracking tables for metering and budget management.
+
+    Implements:
+    - token_usage: Append-only log of all token consumption
+    - token_usage_rollup_daily: Pre-aggregated daily usage for O(1) reads
+    - user_token_budgets: Per-user/workspace budget configuration
+    """
+
+    # Create token_usage table (append-only log)
+    op.create_table(
+        "token_usage",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("request_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workspace_id", sa.String(255), nullable=True),
+        sa.Column("device_session_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("thread_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("model_name", sa.String(100), nullable=True),
+        sa.Column("provider", sa.String(50), nullable=True),
+        sa.Column("tool_calls_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cache_hit", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("status", sa.String(10), nullable=False, server_default="ok"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "request_id", name="uq_token_usage_request_id"
+        ),  # Idempotency
+        sa.CheckConstraint(
+            "status IN ('ok', 'error', 'cache')", name="ck_token_usage_status"
+        ),
+    )
+
+    # Create indexes for efficient queries
+    op.create_index(
+        "idx_token_usage_user_workspace",
+        "token_usage",
+        ["user_id", "workspace_id", "created_at"],
+    )
+    op.create_index(
+        "idx_token_usage_device_session",
+        "token_usage",
+        ["device_session_id", "created_at"],
+    )
+    op.create_index(
+        "idx_token_usage_thread", "token_usage", ["thread_id", "created_at"]
+    )
+    op.create_index("idx_token_usage_created", "token_usage", ["created_at"])
+
+    # Create token_usage_rollup_daily table (pre-aggregated for fast reads)
+    op.create_table(
+        "token_usage_rollup_daily",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workspace_id", sa.String(255), nullable=True),
+        sa.Column("day", sa.Date(), nullable=False),
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("request_count", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("cache_hits", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("error_count", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint(
+            "user_id", "workspace_id", "day", name="pk_token_rollup_daily"
+        ),
+    )
+
+    # Index for efficient rollup queries
+    op.create_index("idx_token_rollup_day", "token_usage_rollup_daily", ["day"])
+    op.create_index(
+        "idx_token_rollup_user", "token_usage_rollup_daily", ["user_id", "day"]
+    )
+
+    # Create user_token_budgets table
+    op.create_table(
+        "user_token_budgets",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workspace_id", sa.String(255), nullable=True),
+        sa.Column(
+            "daily_limit", sa.Integer(), nullable=False, server_default="1000000"
+        ),
+        sa.Column(
+            "monthly_limit", sa.Integer(), nullable=False, server_default="30000000"
+        ),
+        sa.Column(
+            "warning_threshold_percent",
+            sa.Integer(),
+            nullable=False,
+            server_default="80",
+        ),
+        sa.Column("soft_block", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "workspace_id", name="uq_user_workspace_budget"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+    )
+
+    # Add foreign key constraints for token_usage
+    op.create_foreign_key(
+        "fk_token_usage_user",
+        "token_usage",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_token_usage_device_session",
+        "token_usage",
+        "device_sessions",
+        ["device_session_id"],
+        ["session_id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_token_usage_thread",
+        "token_usage",
+        "threads",
+        ["thread_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # Add foreign key for rollup table
+    op.create_foreign_key(
+        "fk_token_rollup_user",
+        "token_usage_rollup_daily",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    """Drop token usage tracking tables."""
+
+    # Drop foreign keys first
+    op.drop_constraint(
+        "fk_token_rollup_user", "token_usage_rollup_daily", type_="foreignkey"
+    )
+    op.drop_constraint("fk_token_usage_thread", "token_usage", type_="foreignkey")
+    op.drop_constraint(
+        "fk_token_usage_device_session", "token_usage", type_="foreignkey"
+    )
+    op.drop_constraint("fk_token_usage_user", "token_usage", type_="foreignkey")
+
+    # Drop tables
+    op.drop_table("user_token_budgets")
+    op.drop_table("token_usage_rollup_daily")
+    op.drop_table("token_usage")

--- a/agent-core/src/db/models.py
+++ b/agent-core/src/db/models.py
@@ -1325,8 +1325,12 @@ class TokenUsageRollupDaily(Base):
         doc="User identifier",
     )
 
-    workspace_id: Mapped[Optional[str]] = mapped_column(
-        String(255), primary_key=True, nullable=True, doc="Workspace (NULL for global)"
+    workspace_id: Mapped[str] = mapped_column(
+        String(255),
+        primary_key=True,
+        nullable=False,
+        server_default="",
+        doc="Workspace (empty string for global)",
     )
 
     day: Mapped[date] = mapped_column(

--- a/agent-core/src/db/models.py
+++ b/agent-core/src/db/models.py
@@ -12,7 +12,7 @@ Security: All OAuth tokens are encrypted at rest using Fernet encryption.
 """
 
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Optional
 
 from sqlalchemy import (
@@ -20,6 +20,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    Date,
     DateTime,
     ForeignKey,
     Index,
@@ -1147,15 +1148,336 @@ class AgentCacheTag(Base):
         doc="Tag for grouping (e.g., notion:page:PAGE_ID)",
     )
 
-    # Relationship
-    cache_entry: Mapped["AgentCache"] = relationship(
-        "AgentCache",
-        back_populates="tags",
-        doc="Parent cache entry",
+
+class TokenUsage(Base):
+    """
+    Token usage tracking for metering and billing.
+
+    Append-only log that tracks every request's token consumption with idempotency
+    via unique request_id constraint. Supports cache hit tracking (zero tokens)
+    and error status tracking.
+
+    Attributes:
+        id: Auto-incrementing primary key
+        request_id: Unique request identifier for idempotency
+        user_id: User who made the request
+        workspace_id: Optional workspace context
+        device_session_id: Optional device session reference
+        thread_id: Optional thread reference
+        input_tokens: Number of input tokens consumed (0 for cache hits)
+        output_tokens: Number of output tokens generated (0 for cache hits)
+        model_name: Model used (e.g., claude-3-opus)
+        provider: Provider name (e.g., anthropic)
+        tool_calls_count: Number of tool calls made
+        cache_hit: Whether this was served from cache
+        status: Request status (ok, error, cache)
+        created_at: Timestamp of usage
+    """
+
+    __tablename__ = "token_usage"
+
+    # Primary key
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True, doc="Auto-incrementing ID"
+    )
+
+    # Request tracking (unique for idempotency)
+    request_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        unique=True,
+        nullable=False,
+        doc="Unique request ID for idempotency",
+    )
+
+    # User and workspace
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        doc="User who made the request",
+    )
+
+    workspace_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, doc="Optional workspace context"
+    )
+
+    # Optional references
+    device_session_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("device_sessions.session_id", ondelete="SET NULL"),
+        nullable=True,
+        doc="Optional device session reference",
+    )
+
+    thread_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("threads.id", ondelete="SET NULL"),
+        nullable=True,
+        doc="Optional thread reference",
+    )
+
+    # Token counts
+    input_tokens: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        doc="Input tokens consumed (0 for cache hits)",
+    )
+
+    output_tokens: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        doc="Output tokens generated (0 for cache hits)",
+    )
+
+    # Model and provider info
+    model_name: Mapped[Optional[str]] = mapped_column(
+        String(100), nullable=True, doc="Model used (e.g., claude-3-opus)"
+    )
+
+    provider: Mapped[Optional[str]] = mapped_column(
+        String(50), nullable=True, doc="Provider name (e.g., anthropic)"
+    )
+
+    # Additional metadata
+    tool_calls_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, doc="Number of tool calls made"
+    )
+
+    cache_hit: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, doc="Whether served from cache"
+    )
+
+    status: Mapped[str] = mapped_column(
+        String(10),
+        nullable=False,
+        default="ok",
+        doc="Request status (ok, error, cache)",
+    )
+
+    # Timestamp
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        doc="Usage timestamp",
     )
 
     # Indexes
-    __table_args__ = (Index("idx_agent_cache_tags_tag", "tag"),)
+    __table_args__ = (
+        Index(
+            "idx_token_usage_user_workspace", "user_id", "workspace_id", "created_at"
+        ),
+        Index("idx_token_usage_device_session", "device_session_id", "created_at"),
+        Index("idx_token_usage_thread", "thread_id", "created_at"),
+        Index("idx_token_usage_created", "created_at"),
+        CheckConstraint(
+            "status IN ('ok', 'error', 'cache')", name="ck_token_usage_status"
+        ),
+    )
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens consumed (input + output)."""
+        return self.input_tokens + self.output_tokens
 
     def __repr__(self) -> str:
-        return f"<AgentCacheTag(key={self.cache_key[:30]}..., tag={self.tag})>"
+        return (
+            f"<TokenUsage(request={str(self.request_id)[:8]}..., "
+            f"tokens={self.total_tokens}, cache_hit={self.cache_hit}, status={self.status})>"
+        )
+
+
+class TokenUsageRollupDaily(Base):
+    """
+    Pre-aggregated daily token usage for O(1) reads.
+
+    Maintained via upserts on every request to avoid expensive aggregation queries.
+    Primary key is (user_id, workspace_id, day) for efficient lookups.
+
+    Attributes:
+        user_id: User identifier
+        workspace_id: Optional workspace (NULL for global)
+        day: UTC date for aggregation
+        input_tokens: Total input tokens for the day
+        output_tokens: Total output tokens for the day
+        request_count: Number of requests made
+        cache_hits: Number of cache hits
+        error_count: Number of errors
+        updated_at: Last update timestamp
+    """
+
+    __tablename__ = "token_usage_rollup_daily"
+
+    # Composite primary key
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+        doc="User identifier",
+    )
+
+    workspace_id: Mapped[Optional[str]] = mapped_column(
+        String(255), primary_key=True, nullable=True, doc="Workspace (NULL for global)"
+    )
+
+    day: Mapped[date] = mapped_column(
+        Date, primary_key=True, doc="UTC date for aggregation"
+    )
+
+    # Aggregated metrics
+    input_tokens: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, doc="Total input tokens"
+    )
+
+    output_tokens: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, doc="Total output tokens"
+    )
+
+    request_count: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, doc="Number of requests"
+    )
+
+    cache_hits: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, doc="Number of cache hits"
+    )
+
+    error_count: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0, doc="Number of errors"
+    )
+
+    # Timestamp
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        onupdate=func.now(),
+        doc="Last update timestamp",
+    )
+
+    # Indexes
+    __table_args__ = (
+        Index("idx_token_rollup_day", "day"),
+        Index("idx_token_rollup_user", "user_id", "day"),
+    )
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens for the day."""
+        return self.input_tokens + self.output_tokens
+
+    @property
+    def cache_hit_rate(self) -> float:
+        """Cache hit rate as percentage."""
+        if self.request_count == 0:
+            return 0.0
+        return (self.cache_hits / self.request_count) * 100
+
+    def __repr__(self) -> str:
+        return (
+            f"<TokenUsageRollupDaily(user={str(self.user_id)[:8]}..., "
+            f"day={self.day}, total={self.total_tokens}, requests={self.request_count})>"
+        )
+
+
+class UserTokenBudget(Base):
+    """
+    Token budget configuration per user/workspace.
+
+    Defines daily and monthly limits with configurable warning thresholds.
+    Supports soft blocking (warning only) and future hard blocking.
+
+    Attributes:
+        id: Unique budget ID
+        user_id: User this budget applies to
+        workspace_id: Optional workspace (NULL for global budget)
+        daily_limit: Daily token limit
+        monthly_limit: Monthly token limit
+        warning_threshold_percent: Percentage for warning (default 80%)
+        soft_block: Whether to only warn (true) or block (false)
+        created_at: Budget creation time
+        updated_at: Last update time
+    """
+
+    __tablename__ = "user_token_budgets"
+
+    # Primary key
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, doc="Unique budget ID"
+    )
+
+    # User and workspace
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        doc="User this budget applies to",
+    )
+
+    workspace_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, doc="Optional workspace (NULL for global)"
+    )
+
+    # Limits
+    daily_limit: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1000000, doc="Daily token limit"
+    )
+
+    monthly_limit: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=30000000, doc="Monthly token limit"
+    )
+
+    # Warning configuration
+    warning_threshold_percent: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=80, doc="Warning threshold percentage"
+    )
+
+    soft_block: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, doc="Only warn, don't block"
+    )
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        doc="Creation timestamp",
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        onupdate=func.now(),
+        doc="Last update timestamp",
+    )
+
+    # Constraints
+    __table_args__ = (
+        UniqueConstraint("user_id", "workspace_id", name="uq_user_workspace_budget"),
+    )
+
+    def get_warning_level(self, usage_percent: float) -> Optional[str]:
+        """
+        Determine warning level based on usage percentage.
+
+        Returns:
+            None if below threshold
+            "warning" if >= warning_threshold_percent
+            "critical" if >= 95%
+            "over" if >= 100%
+        """
+        if usage_percent >= 100:
+            return "over"
+        elif usage_percent >= 95:
+            return "critical"
+        elif usage_percent >= self.warning_threshold_percent:
+            return "warning"
+        return None
+
+    def __repr__(self) -> str:
+        return (
+            f"<UserTokenBudget(user={str(self.user_id)[:8]}..., "
+            f"daily={self.daily_limit}, monthly={self.monthly_limit})>"
+        )

--- a/agent-core/src/db/models.py
+++ b/agent-core/src/db/models.py
@@ -1148,6 +1148,13 @@ class AgentCacheTag(Base):
         doc="Tag for grouping (e.g., notion:page:PAGE_ID)",
     )
 
+    # Relationships
+    cache_entry: Mapped["AgentCache"] = relationship(
+        "AgentCache",
+        back_populates="tags",
+        doc="Associated cache entry",
+    )
+
 
 class TokenUsage(Base):
     """

--- a/agent-core/src/services/token_metering.py
+++ b/agent-core/src/services/token_metering.py
@@ -1,0 +1,434 @@
+"""
+Token metering service for usage tracking and budget management.
+
+This service provides:
+- Request-level token tracking with idempotency
+- Daily rollup maintenance for O(1) reads
+- Budget checking with warning levels
+- Device and thread usage aggregation
+"""
+
+from datetime import date
+from typing import Dict, Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy import Integer, and_, func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.models import TokenUsage, TokenUsageRollupDaily, UserTokenBudget
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class TokenMeteringService:
+    """
+    Service for tracking token usage and managing budgets.
+
+    Features:
+    - Idempotent token tracking via unique request_id
+    - Automatic daily rollup updates for fast queries
+    - Budget checking with warning levels
+    - Cache hit tracking with zero tokens
+    """
+
+    def __init__(self):
+        """Initialize the token metering service."""
+        pass
+
+    async def track_request_tokens(
+        self,
+        db: AsyncSession,
+        *,
+        request_id: UUID,
+        user_id: UUID,
+        workspace_id: Optional[str] = None,
+        device_session_id: Optional[UUID] = None,
+        thread_id: Optional[UUID] = None,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        model_name: Optional[str] = None,
+        provider: Optional[str] = None,
+        cache_hit: bool = False,
+        tool_calls_count: int = 0,
+        status: str = "ok",
+    ) -> None:
+        """
+        Track token usage for a request with idempotency.
+
+        Uses ON CONFLICT to handle retries gracefully, taking the maximum
+        token values to avoid undercounting on partial failures.
+
+        Args:
+            db: Database session
+            request_id: Unique request identifier (for idempotency)
+            user_id: User who made the request
+            workspace_id: Optional workspace context
+            device_session_id: Optional device session
+            thread_id: Optional thread reference
+            input_tokens: Input tokens consumed (0 for cache hits)
+            output_tokens: Output tokens generated (0 for cache hits)
+            model_name: Model used (e.g., claude-3-opus)
+            provider: Provider name (e.g., anthropic)
+            cache_hit: Whether this was served from cache
+            tool_calls_count: Number of tool calls made
+            status: Request status (ok, error, cache)
+        """
+        try:
+            # For cache hits, ensure tokens are zero
+            if cache_hit:
+                input_tokens = 0
+                output_tokens = 0
+                if status == "ok":
+                    status = "cache"
+
+            # Insert or update token usage (idempotent via request_id)
+            stmt = insert(TokenUsage).values(
+                request_id=request_id,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                device_session_id=device_session_id,
+                thread_id=thread_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                model_name=model_name,
+                provider=provider,
+                tool_calls_count=tool_calls_count,
+                cache_hit=cache_hit,
+                status=status,
+            )
+
+            # On conflict, take maximum tokens (handles retries)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["request_id"],
+                set_={
+                    "input_tokens": func.greatest(
+                        TokenUsage.input_tokens, stmt.excluded.input_tokens
+                    ),
+                    "output_tokens": func.greatest(
+                        TokenUsage.output_tokens, stmt.excluded.output_tokens
+                    ),
+                    "status": stmt.excluded.status,
+                    "cache_hit": TokenUsage.cache_hit | stmt.excluded.cache_hit,
+                    "tool_calls_count": func.greatest(
+                        TokenUsage.tool_calls_count, stmt.excluded.tool_calls_count
+                    ),
+                },
+            )
+
+            await db.execute(stmt)
+
+            # Update daily rollup (atomic upsert)
+            await self._update_daily_rollup(
+                db,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_hit=cache_hit,
+                is_error=(status == "error"),
+            )
+
+            logger.debug(
+                "Token usage tracked",
+                request_id=str(request_id),
+                user_id=str(user_id),
+                workspace_id=workspace_id,
+                tokens_in=input_tokens,
+                tokens_out=output_tokens,
+                cache_hit=cache_hit,
+                status=status,
+            )
+
+        except Exception as e:
+            # Log but don't fail the request
+            logger.error(
+                "Failed to track token usage",
+                request_id=str(request_id),
+                error=str(e),
+            )
+
+    async def _update_daily_rollup(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        workspace_id: Optional[str],
+        input_tokens: int,
+        output_tokens: int,
+        cache_hit: bool,
+        is_error: bool,
+    ) -> None:
+        """
+        Update daily rollup table with atomic upsert.
+
+        This maintains pre-aggregated totals for O(1) budget checks.
+        """
+        today = date.today()  # UTC date
+
+        # Prepare values for upsert
+        values = {
+            "user_id": user_id,
+            "workspace_id": workspace_id or "",  # Use empty string for NULL
+            "day": today,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "request_count": 1,
+            "cache_hits": 1 if cache_hit else 0,
+            "error_count": 1 if is_error else 0,
+        }
+
+        # Upsert with atomic addition
+        stmt = insert(TokenUsageRollupDaily).values(**values)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["user_id", "workspace_id", "day"],
+            set_={
+                "input_tokens": TokenUsageRollupDaily.input_tokens
+                + stmt.excluded.input_tokens,
+                "output_tokens": TokenUsageRollupDaily.output_tokens
+                + stmt.excluded.output_tokens,
+                "request_count": TokenUsageRollupDaily.request_count + 1,
+                "cache_hits": TokenUsageRollupDaily.cache_hits
+                + stmt.excluded.cache_hits,
+                "error_count": TokenUsageRollupDaily.error_count
+                + stmt.excluded.error_count,
+                "updated_at": func.now(),
+            },
+        )
+
+        await db.execute(stmt)
+
+    async def get_device_usage(
+        self,
+        db: AsyncSession,
+        device_session_id: UUID,
+        day: Optional[date] = None,
+    ) -> Dict[str, int]:
+        """
+        Get token usage for a device session.
+
+        Args:
+            db: Database session
+            device_session_id: Device session to query
+            day: Specific day (None for today)
+
+        Returns:
+            Dictionary with input_tokens, output_tokens, request_count
+        """
+        if day is None:
+            day = date.today()
+
+        # Query raw usage table for device-specific metrics
+        stmt = select(
+            func.sum(TokenUsage.input_tokens).label("input_tokens"),
+            func.sum(TokenUsage.output_tokens).label("output_tokens"),
+            func.count(TokenUsage.id).label("request_count"),
+            func.sum(func.cast(TokenUsage.cache_hit, Integer)).label("cache_hits"),
+        ).where(
+            and_(
+                TokenUsage.device_session_id == device_session_id,
+                func.date(TokenUsage.created_at) == day,
+            )
+        )
+
+        result = await db.execute(stmt)
+        row = result.one()
+
+        return {
+            "input_tokens": row.input_tokens or 0,
+            "output_tokens": row.output_tokens or 0,
+            "request_count": row.request_count or 0,
+            "cache_hits": row.cache_hits or 0,
+            "day": day.isoformat(),
+        }
+
+    async def get_user_usage(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        workspace_id: Optional[str] = None,
+        day: Optional[date] = None,
+    ) -> Dict[str, int]:
+        """
+        Get token usage for a user from rollup table (O(1)).
+
+        Args:
+            db: Database session
+            user_id: User to query
+            workspace_id: Optional workspace filter
+            day: Specific day (None for today)
+
+        Returns:
+            Dictionary with usage metrics
+        """
+        if day is None:
+            day = date.today()
+
+        # Query rollup table for fast reads
+        stmt = select(TokenUsageRollupDaily).where(
+            and_(
+                TokenUsageRollupDaily.user_id == user_id,
+                TokenUsageRollupDaily.workspace_id == (workspace_id or ""),
+                TokenUsageRollupDaily.day == day,
+            )
+        )
+
+        result = await db.execute(stmt)
+        rollup = result.scalar_one_or_none()
+
+        if not rollup:
+            return {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "request_count": 0,
+                "cache_hits": 0,
+                "error_count": 0,
+                "day": day.isoformat(),
+            }
+
+        return {
+            "input_tokens": rollup.input_tokens,
+            "output_tokens": rollup.output_tokens,
+            "request_count": rollup.request_count,
+            "cache_hits": rollup.cache_hits,
+            "error_count": rollup.error_count,
+            "cache_hit_rate": rollup.cache_hit_rate,
+            "day": day.isoformat(),
+        }
+
+    async def check_budget(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        workspace_id: Optional[str] = None,
+    ) -> Tuple[bool, int, Optional[str]]:
+        """
+        Check if user is over budget threshold.
+
+        Args:
+            db: Database session
+            user_id: User to check
+            workspace_id: Optional workspace
+
+        Returns:
+            Tuple of (over_threshold, percent_used, warning_level)
+            warning_level: None, "warning", "critical", or "over"
+        """
+        # Get or create budget configuration
+        budget = await self._get_or_create_budget(db, user_id, workspace_id)
+
+        # Get today's usage from rollup
+        usage = await self.get_user_usage(db, user_id, workspace_id)
+        total_tokens = usage["input_tokens"] + usage["output_tokens"]
+
+        # Calculate percentage
+        if budget.daily_limit == 0:
+            percent_used = 0
+        else:
+            percent_used = int((total_tokens / budget.daily_limit) * 100)
+
+        # Determine warning level
+        warning_level = budget.get_warning_level(float(percent_used))
+        over_threshold = percent_used >= budget.warning_threshold_percent
+
+        logger.debug(
+            "Budget check",
+            user_id=str(user_id),
+            workspace_id=workspace_id,
+            tokens_used=total_tokens,
+            daily_limit=budget.daily_limit,
+            percent_used=percent_used,
+            warning_level=warning_level,
+        )
+
+        return over_threshold, percent_used, warning_level
+
+    async def _get_or_create_budget(
+        self,
+        db: AsyncSession,
+        user_id: UUID,
+        workspace_id: Optional[str],
+    ) -> UserTokenBudget:
+        """
+        Get or create budget configuration for user/workspace.
+
+        Creates default budget if none exists.
+        """
+        stmt = select(UserTokenBudget).where(
+            and_(
+                UserTokenBudget.user_id == user_id,
+                UserTokenBudget.workspace_id == workspace_id,
+            )
+        )
+
+        result = await db.execute(stmt)
+        budget = result.scalar_one_or_none()
+
+        if not budget:
+            # Create default budget
+            budget = UserTokenBudget(
+                user_id=user_id,
+                workspace_id=workspace_id,
+                daily_limit=1000000,  # 1M tokens default
+                monthly_limit=30000000,  # 30M tokens default
+                warning_threshold_percent=80,
+                soft_block=True,  # Only warn by default
+            )
+            db.add(budget)
+            await db.flush()
+
+        return budget
+
+    async def get_thread_usage(
+        self,
+        db: AsyncSession,
+        thread_id: UUID,
+        day: Optional[date] = None,
+    ) -> Dict[str, int]:
+        """
+        Get token usage for a thread.
+
+        Args:
+            db: Database session
+            thread_id: Thread to query
+            day: Specific day (None for all time)
+
+        Returns:
+            Dictionary with usage metrics
+        """
+        # Build query
+        stmt = select(
+            func.sum(TokenUsage.input_tokens).label("input_tokens"),
+            func.sum(TokenUsage.output_tokens).label("output_tokens"),
+            func.count(TokenUsage.id).label("request_count"),
+            func.sum(func.cast(TokenUsage.cache_hit, Integer)).label("cache_hits"),
+        ).where(TokenUsage.thread_id == thread_id)
+
+        # Add day filter if specified
+        if day:
+            stmt = stmt.where(func.date(TokenUsage.created_at) == day)
+
+        result = await db.execute(stmt)
+        row = result.one()
+
+        return {
+            "input_tokens": row.input_tokens or 0,
+            "output_tokens": row.output_tokens or 0,
+            "request_count": row.request_count or 0,
+            "cache_hits": row.cache_hits or 0,
+            "thread_id": str(thread_id),
+            "day": day.isoformat() if day else "all_time",
+        }
+
+
+# Singleton instance
+_token_metering_service: Optional[TokenMeteringService] = None
+
+
+def get_token_metering_service() -> TokenMeteringService:
+    """Get singleton token metering service instance."""
+    global _token_metering_service
+    if _token_metering_service is None:
+        _token_metering_service = TokenMeteringService()
+    return _token_metering_service

--- a/agent-core/tests/unit/test_token_metering.py
+++ b/agent-core/tests/unit/test_token_metering.py
@@ -1,0 +1,282 @@
+"""
+Unit tests for the token metering service.
+
+Tests cover:
+- Idempotent token tracking
+- Daily rollup updates
+- Budget checking with warning levels
+- Cache hit tracking with zero tokens
+"""
+
+import uuid
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.db.models import TokenUsage, TokenUsageRollupDaily, User, UserTokenBudget
+from src.services.token_metering import TokenMeteringService
+
+
+@pytest.fixture
+def token_metering():
+    """Create a token metering service instance."""
+    return TokenMeteringService()
+
+
+@pytest.fixture
+async def test_user(db_session: AsyncSession):
+    """Create a test user for token tracking."""
+    user = User(
+        id=uuid.uuid4(),
+        email=f"test-{uuid.uuid4().hex[:8]}@example.com",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    db_session.add(user)
+    return user
+
+
+@pytest.fixture
+def test_request_id():
+    """Generate a test request ID."""
+    return uuid.uuid4()
+
+
+class TestTokenMetering:
+    """Test suite for token metering service."""
+
+    async def test_track_request_tokens_basic(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+        test_request_id: uuid.UUID,
+    ):
+        """Test basic token tracking with idempotency."""
+        # Track initial request
+        await token_metering.track_request_tokens(
+            db_session,
+            request_id=test_request_id,
+            user_id=test_user.id,
+            input_tokens=100,
+            output_tokens=50,
+            model_name="claude-3-opus",
+            provider="anthropic",
+        )
+        # Don't commit here - let the test transaction handle it
+
+        # Verify token usage was recorded
+        stmt = select(TokenUsage).where(TokenUsage.request_id == test_request_id)
+        result = await db_session.execute(stmt)
+        usage = result.scalar_one()
+
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.model_name == "claude-3-opus"
+        assert usage.provider == "anthropic"
+        assert usage.status == "ok"
+        assert not usage.cache_hit
+
+    async def test_track_request_tokens_idempotent(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+        test_request_id: uuid.UUID,
+    ):
+        """Test idempotent token tracking with retries."""
+        # Track initial request with partial tokens
+        await token_metering.track_request_tokens(
+            db_session,
+            request_id=test_request_id,
+            user_id=test_user.id,
+            input_tokens=50,
+            output_tokens=25,
+        )
+
+        # Retry with higher token counts (simulating retry)
+        await token_metering.track_request_tokens(
+            db_session,
+            request_id=test_request_id,
+            user_id=test_user.id,
+            input_tokens=100,  # Higher count
+            output_tokens=50,  # Higher count
+        )
+
+        # Verify maximum tokens were kept
+        stmt = select(TokenUsage).where(TokenUsage.request_id == test_request_id)
+        result = await db_session.execute(stmt)
+        usage = result.scalar_one()
+
+        assert usage.input_tokens == 100  # Maximum was kept
+        assert usage.output_tokens == 50  # Maximum was kept
+
+    async def test_cache_hit_zero_tokens(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+        test_request_id: uuid.UUID,
+    ):
+        """Test that cache hits record zero tokens."""
+        # Track cache hit
+        await token_metering.track_request_tokens(
+            db_session,
+            request_id=test_request_id,
+            user_id=test_user.id,
+            input_tokens=999,  # Should be overridden to 0
+            output_tokens=999,  # Should be overridden to 0
+            cache_hit=True,
+        )
+
+        # Verify zero tokens for cache hit
+        stmt = select(TokenUsage).where(TokenUsage.request_id == test_request_id)
+        result = await db_session.execute(stmt)
+        usage = result.scalar_one()
+
+        assert usage.input_tokens == 0
+        assert usage.output_tokens == 0
+        assert usage.cache_hit
+        assert usage.status == "cache"
+
+    async def test_daily_rollup_update(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+    ):
+        """Test daily rollup table updates."""
+        # Track multiple requests
+        for i in range(3):
+            await token_metering.track_request_tokens(
+                db_session,
+                request_id=uuid.uuid4(),
+                user_id=test_user.id,
+                workspace_id="test-workspace",
+                input_tokens=100,
+                output_tokens=50,
+                cache_hit=(i == 2),  # Last one is a cache hit
+            )
+
+        # Check rollup was updated
+        today = date.today()
+        stmt = select(TokenUsageRollupDaily).where(
+            TokenUsageRollupDaily.user_id == test_user.id,
+            TokenUsageRollupDaily.workspace_id == "test-workspace",
+            TokenUsageRollupDaily.day == today,
+        )
+        result = await db_session.execute(stmt)
+        rollup = result.scalar_one()
+
+        assert rollup.input_tokens == 200  # 2 real requests * 100
+        assert rollup.output_tokens == 100  # 2 real requests * 50
+        assert rollup.request_count == 3
+        assert rollup.cache_hits == 1
+        assert rollup.error_count == 0
+
+    async def test_get_user_usage(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+    ):
+        """Test retrieving user usage from rollup."""
+        # Track some usage
+        await token_metering.track_request_tokens(
+            db_session,
+            request_id=uuid.uuid4(),
+            user_id=test_user.id,
+            input_tokens=500,
+            output_tokens=250,
+        )
+
+        # Get usage
+        usage = await token_metering.get_user_usage(
+            db_session,
+            user_id=test_user.id,
+        )
+
+        assert usage["input_tokens"] == 500
+        assert usage["output_tokens"] == 250
+        assert usage["request_count"] == 1
+        assert usage["cache_hits"] == 0
+
+    async def test_budget_check_warning_levels(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+    ):
+        """Test budget checking with warning levels."""
+        # Create custom budget with low limit
+        budget = UserTokenBudget(
+            user_id=test_user.id,
+            workspace_id=None,
+            daily_limit=1000,  # Low limit for testing
+            monthly_limit=30000,
+            warning_threshold_percent=80,
+            soft_block=True,
+        )
+        db_session.add(budget)
+
+        # Track usage at different levels
+        test_cases = [
+            (700, False, None),  # 70% - no warning
+            (800, True, "warning"),  # 80% - warning
+            (950, True, "critical"),  # 95% - critical
+            (1100, True, "over"),  # 110% - over
+        ]
+
+        for total_tokens, expected_over, expected_level in test_cases:
+            # Clear previous usage
+            stmt = select(TokenUsageRollupDaily).where(
+                TokenUsageRollupDaily.user_id == test_user.id
+            )
+            result = await db_session.execute(stmt)
+            for rollup in result.scalars():
+                await db_session.delete(rollup)
+
+            # Track new usage
+            await token_metering.track_request_tokens(
+                db_session,
+                request_id=uuid.uuid4(),
+                user_id=test_user.id,
+                input_tokens=total_tokens,
+                output_tokens=0,
+            )
+
+            # Check budget
+            (
+                over_threshold,
+                percent_used,
+                warning_level,
+            ) = await token_metering.check_budget(
+                db_session,
+                user_id=test_user.id,
+            )
+
+            assert over_threshold == expected_over
+            assert warning_level == expected_level
+            assert percent_used == int((total_tokens / 1000) * 100)
+
+    async def test_device_usage_tracking(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+    ):
+        """Test device-specific usage tracking - skipped as it requires device sessions."""
+        # Skip this test for now as it requires device session setup
+        pytest.skip("Requires device session entity setup")
+
+    async def test_thread_usage_tracking(
+        self,
+        db_session: AsyncSession,
+        token_metering: TokenMeteringService,
+        test_user: User,
+    ):
+        """Test thread-specific usage tracking - skipped as it requires thread setup."""
+        # Skip this test for now as it requires thread entity setup
+        pytest.skip("Requires thread entity setup")


### PR DESCRIPTION
## Summary
Implements comprehensive token usage metering with budget warnings at 80% threshold.

## Implementation Details

### Database Schema
- **token_usage**: Append-only log with idempotent tracking via unique request_id
- **token_usage_rollup_daily**: Pre-aggregated daily metrics for O(1) budget checks  
- **user_token_budgets**: Per-user/workspace budget configuration with warning thresholds

### Key Features
- ✅ Idempotent token tracking with ON CONFLICT handling
- ✅ Daily rollup updates via atomic upserts
- ✅ Cache hits tracked with zero tokens
- ✅ Budget warnings at 80% (warning), 95% (critical), 100% (over)
- ✅ Integration with Pydantic AI usage extraction
- ✅ Response metadata includes budgetWarning and budgetPercentUsed

### Architecture Decisions
- **Orchestrator owns metering**: All tracking in try/finally blocks prevents double counting
- **Router owns warnings**: Only checks budget, doesn't call metering service
- **Rollup tables**: Pre-aggregated data for fast budget checks vs expensive queries
- **GREATEST() for retries**: Ensures maximum token count is kept on retries

### Testing
- 6 tests passing covering idempotency, cache hits, rollups, budget warnings
- 2 tests skipped (device/thread tracking - require entity setup)

## Acceptance Criteria
- [x] Track token usage per request with idempotency
- [x] Add meta.tokens.used to response
- [x] Warn at 80% budget threshold
- [x] Handle cache hits with zero tokens
- [x] Daily rollup maintenance for fast queries

Closes #26